### PR TITLE
Create authenticator docker image for deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,12 @@ WORKDIR /usr/src/approzium/authenticator
 COPY authenticator/ .
 RUN --mount=type=cache,target=$GOPATH/pkg/mod go build
 
-FROM alpine:latest AS build
+FROM alpine:latest AS authenticator-build
 WORKDIR /app/
 COPY --from=dev /usr/src/approzium/authenticator/authenticator .
+ENTRYPOINT ["./authenticator"]
+
+FROM authenticator-build AS authenticator-dev
 COPY --from=dev /usr/src/approzium/authenticator/server/testing/approzium.pem .
 RUN chmod 644 /app/approzium.pem
 COPY --from=dev /usr/src/approzium/authenticator/server/testing/approzium.key .
@@ -46,4 +49,3 @@ RUN chmod 644 /app/approzium.key
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 COPY --from=dev /usr/src/approzium/authenticator/server/testing/ca.cert /usr/local/share/ca-certificates/self-signed-ca.cert
 RUN chmod 644 /usr/local/share/ca-certificates/self-signed-ca.cert && update-ca-certificates
-ENTRYPOINT ["./authenticator"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     authenticator:
         build:
             context: ./
-            target: build
+            target: authenticator-dev
         environment:
             - APPROZIUM_HOST=0.0.0.0
             - APPROZIUM_DISABLE_TLS=true


### PR DESCRIPTION
- Change `build` image into `authenticator-build` which does not have self-signed certs and is the image we publish, and `authenticator-dev` which has certs and is used in tests.