### PR TITLE
Add --version and --dev flags

### DIFF
--- a/authenticator/Makefile
+++ b/authenticator/Makefile
@@ -4,7 +4,7 @@ dev:
 	go build && go install
 
 test:
-	go test -v -race -p 1 ./...
+	go test -v -race ./...
 
 server:
 	go build .

--- a/authenticator/README.md
+++ b/authenticator/README.md
@@ -11,7 +11,7 @@ the password.
 We love contributions. To easily develop, in the `authenticator` folder, run `$ make dev`. Then, run the authenticator.
 
 ```
-$ authenticator -dev
+$ authenticator --dev
 ```
 
 It will start the authenticator up on your `localhost` without TLS. Check that it's up by hitting its API.

--- a/authenticator/main.go
+++ b/authenticator/main.go
@@ -12,10 +12,18 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const currentVersion = "0.1.1"
+
 func main() {
-	c, err := config.ParseConfig()
+	c, err := config.Parse()
 	if err != nil {
 		log.Errorf("couldn't parse config: %s", err)
+		return
+	}
+
+	if c.Version {
+		// Just output the version and be done.
+		fmt.Println("Approzium v" + currentVersion)
 		return
 	}
 

--- a/authenticator/server/config/config_test.go
+++ b/authenticator/server/config/config_test.go
@@ -10,7 +10,7 @@ func TestParseConfig(t *testing.T) {
 	os.Unsetenv("APPROZIUM_HTTP_PORT")
 	os.Unsetenv("APPROZIUM_LOG_LEVEL")
 	os.Setenv("APPROZIUM_DISABLE_TLS", "true")
-	config, err := ParseConfig()
+	config, err := Parse()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +28,7 @@ func TestParseConfig(t *testing.T) {
 	os.Setenv("APPROZIUM_HTTP_PORT", "6001")
 	os.Setenv("APPROZIUM_LOG_LEVEL", "debug")
 	os.Setenv("APPROZIUM_DISABLE_TLS", "true")
-	config, err = ParseConfig()
+	config, err = Parse()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Closes #126 

I've also added a note to our release instructions to manually bump the version number each time.

```
➜  authenticator git:(develop) authenticator --version
Approzium v0.1.1
```

```
➜  authenticator git:(develop) authenticator --dev
INFO   [2020-07-14T10:42:28-07:00] api starting on https://127.0.0.1:6000
INFO   [2020-07-14T10:42:32-07:00] loading secrets at "/Users/rebeccapetrin/go/src/github.com/cyralinc/approzium/authenticator/server/testing/secrets.yaml"
INFO   [2020-07-14T10:42:32-07:00] secrets loaded, please restart authenticator to load edits
INFO   [2020-07-14T10:42:32-07:00] selected local file as credential manager
WARNING[2020-07-14T10:42:32-07:00] local file credential manager should not be used in production
INFO   [2020-07-14T10:42:32-07:00] grpc starting on https://127.0.0.1:6001
INFO   [2020-07-14T10:42:32-07:00] all ports up and ready to serve traffic
```