### PR TITLE
Fix non-TLS Connection to Authenticator

### DIFF
--- a/sdk/python/approzium/_authenticator.py
+++ b/sdk/python/approzium/_authenticator.py
@@ -58,14 +58,13 @@ class AuthClient(object):
                     "if tls is not disabled, "
                     "client_cert and client_key must be provided"
                 )
-
-        self.disable_tls = disable_tls
-        if not disable_tls:
             self.tls_config = TLSConfig(
                 trusted_certs=tls_config.trusted_certs,
                 client_cert=tls_config.client_cert,
                 client_key=tls_config.client_key,
             )
+
+        self.disable_tls = disable_tls
         self.authenticated = False
         self._counter = count(1)
         self.n_conns = 0

--- a/sdk/python/approzium/_authenticator.py
+++ b/sdk/python/approzium/_authenticator.py
@@ -60,11 +60,12 @@ class AuthClient(object):
                 )
 
         self.disable_tls = disable_tls
-        self.tls_config = TLSConfig(
-            trusted_certs=tls_config.trusted_certs,
-            client_cert=tls_config.client_cert,
-            client_key=tls_config.client_key,
-        )
+        if not disable_tls:
+            self.tls_config = TLSConfig(
+                trusted_certs=tls_config.trusted_certs,
+                client_cert=tls_config.client_cert,
+                client_key=tls_config.client_key,
+            )
         self.authenticated = False
         self._counter = count(1)
         self.n_conns = 0

--- a/sdk/python/examples/psycopg2_connect.py
+++ b/sdk/python/examples/psycopg2_connect.py
@@ -1,3 +1,4 @@
+import approzium
 from approzium import AuthClient
 from approzium.psycopg2 import connect
 from approzium.psycopg2.pool import ThreadedConnectionPool
@@ -11,6 +12,7 @@ dsn = "host=dbmd5 dbname=db user=bob"
 conn = connect(dsn, authenticator=auth)
 print("Connection Established")
 
+approzium.default_auth_client = auth
 conns = ThreadedConnectionPool(1, 5, dsn)
 conn = conns.getconn()
 print("Connection Pool Established")


### PR DESCRIPTION
- Fixed issue where having `disable_tls=True` when instantiating an AuthClient still required a TLSconfig argument.
- Fixed error when running example by setting the default auth client instead of passing it in.