### PR TITLE
unitalicize keywords in code blocks

### DIFF
--- a/docs/src/theme/CodeBlock/index.js
+++ b/docs/src/theme/CodeBlock/index.js
@@ -230,9 +230,11 @@ export default ({ children, className: languageClassName, metastring, landingPag
 
                   return (
                     <div key={i} {...lineProps}>
-                      {line.map((token, key) => (
-                        <span key={key} {...getTokenProps({ token, key })} />
-                      ))}
+                      {line.map((token, key) => {
+                        const tokenProps = getTokenProps({ token, key })
+                        if (tokenProps.className == "token keyword") tokenProps.style.fontStyle = null
+                        return <span key={key} {...tokenProps} />
+                      })}
                     </div>
                   );
                 })}


### PR DESCRIPTION
By default, "keywords" (like `from` and `import` in python) are italicized by the code highlighting package ([Prism](https://prismjs.com/)), but I thought it looked a bit unnatural. What do y'all think?

Original
![image](https://user-images.githubusercontent.com/22224579/87633971-40838300-c6f1-11ea-9dc7-d2ff36023e52.png)

With change
![image](https://user-images.githubusercontent.com/22224579/87633997-4da07200-c6f1-11ea-9af2-7b6cec4c14bb.png)

