### PR TITLE
docs: Add GitHub Security Policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,5 @@
+# Reporiting Security Issues
+
+We take Approzium's security and our users' trust very seriously. If you believe you
+have found a security issue in Approzium, _please responsibly disclose_ by contacting
+us at [security@cyral.com](mailto:security@cyral.com) before filing any public issues.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ identity is provided through the platform on which you're running.
 
 **Please note**: We take Approzium's security and our users' trust very seriously. If you believe you have found a security issue in Approzium, _please responsibly disclose_ by contacting us at [security@cyral.com](mailto:security@cyral.com).
 
+See the [SECURITY](.github/SECURITY.md) guide for more details.
+
 ----
 
 We currently support AWS for identity, and have a Python SDK for Postgres drivers. This project is under active development, please


### PR DESCRIPTION
# Description

Adds a doc on reporting security issues to `.github/SECURITY.md`. This
allows GitHub to display information on how to report such issues.

When creating an Issue or PR, GitHub will present links to this security
policy. The policy is also accessible from the Security tab on the main
page of the repo.

This mostly just moves the existing information in the README to the
appropriate location for this GitHub feature.

# Screenshots

Here are some screenshots of this GitHub feature.

## New Issue page

<img width="532" alt="Screen Shot 2020-07-17 at 4 07 34 PM" src="https://user-images.githubusercontent.com/671968/87831213-6f603d00-c848-11ea-982e-8985e491af3e.png">

## Security policy section (from the Security tab)

With the SECURITY.md file in place, GitHub will display the contents of the Markdown file in this section.

<img width="1126" alt="Screen Shot 2020-07-17 at 4 13 58 PM" src="https://user-images.githubusercontent.com/671968/87831244-8acb4800-c848-11ea-92d0-b1e136e53100.png">
