### PR TITLE
Fix TLS flag

### DIFF
--- a/authenticator/server/config/config.go
+++ b/authenticator/server/config/config.go
@@ -159,7 +159,7 @@ func setConfigFlags() {
 		pflag.String("httpport", "", "")
 		pflag.String("grpcport", "", "")
 
-		pflag.String("disabletls", "", "")
+		pflag.Bool("disabletls", false, "")
 		pflag.String("tlscertpath", "", "")
 		pflag.String("tlskeypath", "", "")
 


### PR DESCRIPTION
On my branch, I noticed I'd marked the command-line TLS flag as the wrong type.