### PR TITLE
Clarify Docs for Installing Database Drivers Alongside SDK

### DIFF
--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -52,7 +52,7 @@ vault write approzium/1.2.3.4:5432 @dbuser1-creds.json
 ## SDK Usage
 Install the SDK in your client.
 ```shell
-pip3 install approzium[sqllibs]
+pip3 install 'approzium[sqllibs]'
 ```
 
 Connect to your database as follows. (Note: TLS should **not** be disabled in production environments,

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -52,7 +52,7 @@ vault write approzium/1.2.3.4:5432 @dbuser1-creds.json
 ## SDK Usage
 Install the SDK in your client.
 ```shell
-pip3 install approzium
+pip3 install approzium[sqllibs]
 ```
 
 Connect to your database as follows. (Note: TLS should **not** be disabled in production environments,

--- a/sdk/python/docs/source/userguide.rst
+++ b/sdk/python/docs/source/userguide.rst
@@ -3,7 +3,15 @@ Installation
 
 The last stable release is available on PyPI and can be installed with ``pip``::
 
-    $ python3 -m pip install approzium
+    $ pip3 install approzium
+
+This installs only the approzium SDK. If you would like to additionally install all supported database drivers libraries, run::
+
+    $ pip3 install approzium[sqllibs]
+
+To install Opentelemetry and other dependencies for generating tracing::
+
+    $ pip3 install approzium[tracing]
 
 Requirements
 ------------

--- a/sdk/python/docs/source/userguide.rst
+++ b/sdk/python/docs/source/userguide.rst
@@ -7,11 +7,11 @@ The last stable release is available on PyPI and can be installed with ``pip``::
 
 This installs only the approzium SDK. If you would like to additionally install all supported database drivers libraries, run::
 
-    $ pip3 install approzium[sqllibs]
+    $ pip3 install 'approzium[sqllibs]'
 
 To install Opentelemetry and other dependencies for generating tracing::
 
-    $ pip3 install approzium[tracing]
+    $ pip3 install 'approzium[tracing]'
 
 Requirements
 ------------


### PR DESCRIPTION
By default, the SDK does not install all of its supported database drivers. However, for ease of use, they could be installed using pip optional features, which allow us to run `pip3 install approzium[sqllibs]` or `pip3 install approzium[tracing]`. The first command is the one used in the quickstart, and the more detailed explanation is in the Python SDK user guide.

closes #162 