### PR TITLE
Add gosec Security Checks to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,11 @@ jobs:
       - name: gofmt
         run: gofmt -s -w .
 
+      - name: gosec
+        uses: securego/gosec@master
+        withs:
+            args: ./...
+
       - name: Setup Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,8 @@ jobs:
         uses: securego/gosec@master
         with:
             args: ./...
+        env:
+            GO111MODULE: on
 
       - name: Setup Python
         uses: actions/setup-python@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,6 @@ jobs:
 
       - name: gosec
         uses: securego/gosec@master
-        env:
-          GO111MODULE: "on"
         with:
             args: ./...
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: gosec
         uses: securego/gosec@master
-        withs:
+        with:
             args: ./...
 
       - name: Setup Python

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
         run: gofmt -s -w .
       
       - name: DEBUG
-        run: echo $GO111MODULE
+        run: go version
 
       - name: gosec
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,16 +13,14 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.13'
-      - run: go version
         
       - name: gofmt
         run: gofmt -s -w .
         
       - name: gosec
-        run: |
-          export PATH=$PATH:$(go env GOPATH)/bin
-          go get github.com/securego/gosec/cmd/gosec
-          GO111MODULE=on gosec ./...  
+        uses: securego/gosec@master
+        with:
+          args: ./…  
 
       - name: Setup Python
         uses: actions/setup-python@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,9 @@ jobs:
       GO111MODULE: on
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.13.8' # The Go version to download (if necessary) and use.
 
       - name: gofmt
         run: gofmt -s -w .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    env:
+        GO111MODULE: on
     steps:
       - uses: actions/checkout@v2
 
@@ -16,8 +18,6 @@ jobs:
         uses: securego/gosec@master
         with:
             args: ./...
-        env:
-            GO111MODULE: on
 
       - name: Setup Python
         uses: actions/setup-python@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: gosec
         uses: securego/gosec@master
         env:
-          GO111MODUE: on 
+          GO111MODULE: "on"
         with:
             args: ./...
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,9 @@ jobs:
 
       - name: gofmt
         run: gofmt -s -w .
+      
+      - name: DEBUG
+        run: echo $GO111MODULE
 
       - name: gosec
         uses: securego/gosec@master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     env:
-        GO111MODULE: on
+      GO111MODULE: on
     steps:
       - uses: actions/checkout@v2
 
@@ -16,6 +16,8 @@ jobs:
 
       - name: gosec
         uses: securego/gosec@master
+        env:
+          GO111MODUE: on 
         with:
             args: ./...
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,14 +12,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.13.8' # The Go version to download (if necessary) and use.
-
+          go-version: '1.13'
+      - run: go version
+        
       - name: gofmt
         run: gofmt -s -w .
-      
-      - name: DEBUG
-        run: go version
-
+        
       - name: gosec
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,9 +18,10 @@ jobs:
         run: echo $GO111MODULE
 
       - name: gosec
-        uses: securego/gosec@master
-        with:
-            args: ./...
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          go get github.com/securego/gosec/cmd/gosec
+          GO111MODULE=on gosec ./...  
 
       - name: Setup Python
         uses: actions/setup-python@v1

--- a/authenticator/server/authenticator.go
+++ b/authenticator/server/authenticator.go
@@ -252,7 +252,10 @@ func (a *authenticator) GetPGSHA256Hash(ctx context.Context, req *pb.PGSHA256Has
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
-	sproof := computePGSHA256Sproof(saltedPass, authMsg)
+	sproof, err := computePGSHA256Sproof(saltedPass, authMsg)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+	}
 	return &pb.PGSHA256Response{Cproof: cproof, Sproof: sproof}, nil
 }
 
@@ -312,7 +315,9 @@ func computeMD5(s string, salt []byte) (string, error) {
 	if _, err := io.WriteString(hasher, s); err != nil {
 		return "", err
 	}
-	hasher.Write(salt)
+    if _, err := hasher.Write(salt); err != nil {
+		return "", err
+	}
 	hashedBytes := hasher.Sum(nil)
 	return hex.EncodeToString(hashedBytes), nil
 }
@@ -355,11 +360,15 @@ func xorBytes(a, b []byte) ([]byte, error) {
 // SCRAM reference: https://en.wikipedia.org/wiki/Salted_Challenge_Response_Authentication_Mechanism
 func computePGSHA256Cproof(spassword []byte, authMsg string) (string, error) {
 	mac := hmac.New(sha256.New, spassword)
-	mac.Write([]byte("Client Key"))
+    if _, err := mac.Write([]byte("Client Key")); err != nil {
+		return "", err
+    }
 	ckey := mac.Sum(nil)
 	ckeyHash := sha256.Sum256(ckey)
 	cproofHmac := hmac.New(sha256.New, ckeyHash[:])
-	cproofHmac.Write([]byte(authMsg))
+	if _, err := cproofHmac.Write([]byte(authMsg)); err != nil {
+		return "", err
+    }
 	cproof, err := xorBytes(cproofHmac.Sum(nil), ckey)
 	if err != nil {
 		return "", err
@@ -368,15 +377,19 @@ func computePGSHA256Cproof(spassword []byte, authMsg string) (string, error) {
 	return cproof64, nil
 }
 
-func computePGSHA256Sproof(spassword []byte, authMsg string) string {
+func computePGSHA256Sproof(spassword []byte, authMsg string) (string, error) {
 	mac := hmac.New(sha256.New, spassword)
-	mac.Write([]byte("Server Key"))
+    if _, err := mac.Write([]byte("Server Key")); err != nil {
+		return "", err
+    }
 	skey := mac.Sum(nil)
 	sproofHmac := hmac.New(sha256.New, skey)
-	sproofHmac.Write([]byte(authMsg))
+    if _, err := sproofHmac.Write([]byte(authMsg)); err != nil {
+		return "", err
+    }
 	sproof := sproofHmac.Sum(nil)
 	sproof64 := base64.StdEncoding.EncodeToString(sproof)
-	return sproof64
+	return sproof64, nil
 }
 
 func computeMYSQLSHA1Hash(password string, salt []byte) ([]byte, error) {
@@ -386,11 +399,17 @@ func computeMYSQLSHA1Hash(password string, salt []byte) ([]byte, error) {
 	}
 	firstHash := hasher.Sum(nil)
 	hasher = sha1.New() // #nosec
-	hasher.Write(firstHash)
+    if _, err := hasher.Write(firstHash); err != nil {
+		return nil, err
+    }
 	secondHash := hasher.Sum(nil)
 	hasher = sha1.New() // #nosec
-	hasher.Write(salt)
-	hasher.Write(secondHash)
+    if _, err := hasher.Write(salt); err != nil {
+		return nil, err
+    }
+    if _, err := hasher.Write(secondHash); err != nil {
+		return nil, err
+    }
 	thirdHash := hasher.Sum(nil)
 	finalHash, err := xorBytes(firstHash, thirdHash)
 	if err != nil {

--- a/authenticator/server/authenticator.go
+++ b/authenticator/server/authenticator.go
@@ -13,7 +13,7 @@ a stateful, clustered design. Thanks!
 import (
 	"context"
 	"crypto/hmac"
-	"crypto/md5" // #nosec
+	"crypto/md5"  // #nosec
 	"crypto/sha1" // #nosec
 	"crypto/sha256"
 	"encoding/base64"
@@ -315,7 +315,7 @@ func computeMD5(s string, salt []byte) (string, error) {
 	if _, err := io.WriteString(hasher, s); err != nil {
 		return "", err
 	}
-    if _, err := hasher.Write(salt); err != nil {
+	if _, err := hasher.Write(salt); err != nil {
 		return "", err
 	}
 	hashedBytes := hasher.Sum(nil)
@@ -360,15 +360,15 @@ func xorBytes(a, b []byte) ([]byte, error) {
 // SCRAM reference: https://en.wikipedia.org/wiki/Salted_Challenge_Response_Authentication_Mechanism
 func computePGSHA256Cproof(spassword []byte, authMsg string) (string, error) {
 	mac := hmac.New(sha256.New, spassword)
-    if _, err := mac.Write([]byte("Client Key")); err != nil {
+	if _, err := mac.Write([]byte("Client Key")); err != nil {
 		return "", err
-    }
+	}
 	ckey := mac.Sum(nil)
 	ckeyHash := sha256.Sum256(ckey)
 	cproofHmac := hmac.New(sha256.New, ckeyHash[:])
 	if _, err := cproofHmac.Write([]byte(authMsg)); err != nil {
 		return "", err
-    }
+	}
 	cproof, err := xorBytes(cproofHmac.Sum(nil), ckey)
 	if err != nil {
 		return "", err
@@ -379,14 +379,14 @@ func computePGSHA256Cproof(spassword []byte, authMsg string) (string, error) {
 
 func computePGSHA256Sproof(spassword []byte, authMsg string) (string, error) {
 	mac := hmac.New(sha256.New, spassword)
-    if _, err := mac.Write([]byte("Server Key")); err != nil {
+	if _, err := mac.Write([]byte("Server Key")); err != nil {
 		return "", err
-    }
+	}
 	skey := mac.Sum(nil)
 	sproofHmac := hmac.New(sha256.New, skey)
-    if _, err := sproofHmac.Write([]byte(authMsg)); err != nil {
+	if _, err := sproofHmac.Write([]byte(authMsg)); err != nil {
 		return "", err
-    }
+	}
 	sproof := sproofHmac.Sum(nil)
 	sproof64 := base64.StdEncoding.EncodeToString(sproof)
 	return sproof64, nil
@@ -399,17 +399,17 @@ func computeMYSQLSHA1Hash(password string, salt []byte) ([]byte, error) {
 	}
 	firstHash := hasher.Sum(nil)
 	hasher = sha1.New() // #nosec
-    if _, err := hasher.Write(firstHash); err != nil {
+	if _, err := hasher.Write(firstHash); err != nil {
 		return nil, err
-    }
+	}
 	secondHash := hasher.Sum(nil)
 	hasher = sha1.New() // #nosec
-    if _, err := hasher.Write(salt); err != nil {
+	if _, err := hasher.Write(salt); err != nil {
 		return nil, err
-    }
-    if _, err := hasher.Write(secondHash); err != nil {
+	}
+	if _, err := hasher.Write(secondHash); err != nil {
 		return nil, err
-    }
+	}
 	thirdHash := hasher.Sum(nil)
 	finalHash, err := xorBytes(firstHash, thirdHash)
 	if err != nil {

--- a/authenticator/server/authenticator.go
+++ b/authenticator/server/authenticator.go
@@ -13,8 +13,8 @@ a stateful, clustered design. Thanks!
 import (
 	"context"
 	"crypto/hmac"
-	"crypto/md5"
-	"crypto/sha1"
+	"crypto/md5" // #nosec
+	"crypto/sha1" // #nosec
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -308,7 +308,7 @@ func toDatabaseARN(logger *log.Entry, fullIAMArn string) (string, error) {
 }
 
 func computeMD5(s string, salt []byte) (string, error) {
-	hasher := md5.New()
+	hasher := md5.New() // #nosec
 	if _, err := io.WriteString(hasher, s); err != nil {
 		return "", err
 	}
@@ -380,15 +380,15 @@ func computePGSHA256Sproof(spassword []byte, authMsg string) string {
 }
 
 func computeMYSQLSHA1Hash(password string, salt []byte) ([]byte, error) {
-	hasher := sha1.New()
+	hasher := sha1.New() // #nosec
 	if _, err := io.WriteString(hasher, password); err != nil {
 		return nil, err
 	}
 	firstHash := hasher.Sum(nil)
-	hasher = sha1.New()
+	hasher = sha1.New() // #nosec
 	hasher.Write(firstHash)
 	secondHash := hasher.Sum(nil)
-	hasher = sha1.New()
+	hasher = sha1.New() // #nosec
 	hasher.Write(salt)
 	hasher.Write(secondHash)
 	thirdHash := hasher.Sum(nil)

--- a/authenticator/server/config/config.go
+++ b/authenticator/server/config/config.go
@@ -48,9 +48,9 @@ func Parse() (Config, error) {
 	}
 	if config.devMode {
 		// dev mode uses the file back-end
-        if err := os.Unsetenv("VAULT_ADDR"); err != nil {
-            return Config{}, err
-        }
+		if err := os.Unsetenv("VAULT_ADDR"); err != nil {
+			return Config{}, err
+		}
 		config = Config{
 			Host:       "127.0.0.1",
 			HTTPPort:   6000,
@@ -187,11 +187,11 @@ func setConfigFlags() error {
 	}
 
 	pflag.Parse()
-    if err := viper.BindPFlags(pflag.CommandLine); err != nil {
-        return err
-    }
-    if err := viper.BindPFlag("configfilepath", pflag.Lookup("config")); err != nil {
-        return err
-    }
-    return nil
+	if err := viper.BindPFlags(pflag.CommandLine); err != nil {
+		return err
+	}
+	if err := viper.BindPFlag("configfilepath", pflag.Lookup("config")); err != nil {
+		return err
+	}
+	return nil
 }

--- a/authenticator/server/config/config.go
+++ b/authenticator/server/config/config.go
@@ -48,7 +48,9 @@ func Parse() (Config, error) {
 	}
 	if config.devMode {
 		// dev mode uses the file back-end
-		os.Unsetenv("VAULT_ADDR")
+        if err := os.Unsetenv("VAULT_ADDR"); err != nil {
+            return Config{}, err
+        }
 		config = Config{
 			Host:       "127.0.0.1",
 			HTTPPort:   6000,
@@ -65,7 +67,9 @@ func Parse() (Config, error) {
 func parse() (Config, error) {
 	var config Config
 	setConfigDefaults()
-	setConfigFlags()
+	if err := setConfigFlags(); err != nil {
+		return Config{}, err
+	}
 	if err := setConfigEnvVars(); err != nil {
 		return Config{}, err
 	}
@@ -158,7 +162,7 @@ func setConfigDefaults() {
 	viper.SetDefault("SecretsManager", "")
 }
 
-func setConfigFlags() {
+func setConfigFlags() error {
 	// avoid redefining flags because it leads to panic
 	if pflag.Lookup("host") == nil {
 		pflag.String("host", "", "")
@@ -183,6 +187,11 @@ func setConfigFlags() {
 	}
 
 	pflag.Parse()
-	viper.BindPFlags(pflag.CommandLine)
-	viper.BindPFlag("configfilepath", pflag.Lookup("config"))
+    if err := viper.BindPFlags(pflag.CommandLine); err != nil {
+        return err
+    }
+    if err := viper.BindPFlag("configfilepath", pflag.Lookup("config")); err != nil {
+        return err
+    }
+    return nil
 }

--- a/authenticator/server/credmgrs/hc_vault.go
+++ b/authenticator/server/credmgrs/hc_vault.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+    "path/filepath"
 	"os"
 
 	"github.com/cyralinc/approzium/authenticator/server/config"
@@ -75,7 +76,7 @@ func (h *hcVaultCredMgr) vaultClient() (*vault.Client, error) {
 	// Only use the token sink if there's not already an environmental
 	// VAULT_TOKEN.
 	if h.tokenPath != "" && os.Getenv(vault.EnvVaultToken) == "" {
-		tokenBytes, err := ioutil.ReadFile(h.tokenPath)
+		tokenBytes, err := ioutil.ReadFile(filepath.Clean(h.tokenPath))
 		if err != nil {
 			return nil, err
 		}

--- a/authenticator/server/credmgrs/hc_vault.go
+++ b/authenticator/server/credmgrs/hc_vault.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-    "path/filepath"
 	"os"
+	"path/filepath"
 
 	"github.com/cyralinc/approzium/authenticator/server/config"
 	vault "github.com/hashicorp/vault/api"

--- a/authenticator/server/credmgrs/hc_vault.go
+++ b/authenticator/server/credmgrs/hc_vault.go
@@ -82,7 +82,10 @@ func (h *hcVaultCredMgr) vaultClient() (*vault.Client, error) {
 		}
 		// There is no way to directly pass in the token, so we
 		// must set it in the environment.
-		os.Setenv(vault.EnvVaultToken, string(tokenBytes))
+		err = os.Setenv(vault.EnvVaultToken, string(tokenBytes))
+		if err != nil {
+			return nil, err
+		}
 		defer os.Unsetenv(vault.EnvVaultToken)
 	}
 

--- a/authenticator/server/credmgrs/local_file.go
+++ b/authenticator/server/credmgrs/local_file.go
@@ -3,6 +3,7 @@ package credmgrs
 import (
 	"io/ioutil"
 	"os"
+    "path/filepath"
 	"runtime"
 	"strings"
 
@@ -34,7 +35,7 @@ func newLocalFileCreds(logger *log.Logger, _ config.Config) (CredentialManager, 
 	logger.Infof("loading secrets at %q", pathToSecrets)
 
 	var devCreds secrets
-	yamlFile, err := ioutil.ReadFile(pathToSecrets)
+	yamlFile, err := ioutil.ReadFile(filepath.Clean(pathToSecrets))
 	if err != nil {
 		return &localFileCredMgr{}, err
 	}

--- a/authenticator/server/credmgrs/local_file.go
+++ b/authenticator/server/credmgrs/local_file.go
@@ -3,7 +3,7 @@ package credmgrs
 import (
 	"io/ioutil"
 	"os"
-    "path/filepath"
+	"path/filepath"
 	"runtime"
 	"strings"
 

--- a/authenticator/server/identity/aws.go
+++ b/authenticator/server/identity/aws.go
@@ -99,7 +99,7 @@ func (a *aws) executeGetCallerIdentity(signedGetCallerIdentity string, clientLan
 	case pb.ClientLanguage_GO:
 		resp, err = http.Get(signedGetCallerIdentity) // #nosec: URL is verified before execution
 	case pb.ClientLanguage_PYTHON:
-        resp, err = http.Post(signedGetCallerIdentity, "", nil) // #nosec: URL is verified before execution
+		resp, err = http.Post(signedGetCallerIdentity, "", nil) // #nosec: URL is verified before execution
 	case pb.ClientLanguage_LANGUAGE_NOT_PROVIDED:
 		return "", fmt.Errorf("client language must be provided for AWS authentication")
 	default:

--- a/authenticator/server/identity/aws.go
+++ b/authenticator/server/identity/aws.go
@@ -97,9 +97,9 @@ func (a *aws) executeGetCallerIdentity(signedGetCallerIdentity string, clientLan
 	var err error
 	switch clientLanguage {
 	case pb.ClientLanguage_GO:
-		resp, err = http.Get(signedGetCallerIdentity)
+		resp, err = http.Get(signedGetCallerIdentity) // #nosec: URL is verified before execution
 	case pb.ClientLanguage_PYTHON:
-		resp, err = http.Post(signedGetCallerIdentity, "", nil)
+        resp, err = http.Post(signedGetCallerIdentity, "", nil) // #nosec: URL is verified before execution
 	case pb.ClientLanguage_LANGUAGE_NOT_PROVIDED:
 		return "", fmt.Errorf("client language must be provided for AWS authentication")
 	default:


### PR DESCRIPTION
in addition to title, this PR includes some fixes to the code (and where appropriate, gosec "ignore" annotations ) to appease gosec's checks.

Thanks to Daniel Tobin's [blogpost](https://cyral.com/blog/security-as-code-implementing-lint-and-gosec/) for bringing this tool to my attention.