### PR TITLE
Add Releasing to CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,9 @@ jobs:
 
       - name: Release Authenticator Binaries
         uses: goreleaser/goreleaser-action@v1
-        working-directory: ./authenticator/
         with:
           version: latest
+          workdir: authenticator
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,5 +9,21 @@ jobs:
     env:
       GO111MODULE: on
     steps:
-      - name: Checkout Source 
+      - name: Checkout Source
         uses: actions/checkout@v2
+
+      - uses: actions/setup-go@v2
+        with:
+            go-version: '1.13'
+
+      - name : Get release version
+        id: get_version
+        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+
+      - name: Release Authenticator Binaries
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout Source 
+        uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,13 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish PYPI package
+      - name: Publish Python SDK
         uses: abatilo/actions-poetry@v1.5.0
         with:
             python_version: 3.7.8
             poetry_version: 1.0
             working_directory: ./sdk/python/
-            args: build
+            args: publish --build
+        env:
+          POETRY_HTTP_BASIC_PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          POETRY_HTTP_BASIC_PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,33 +20,32 @@ jobs:
         id: get_version
         run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
 
-#     - name: Release Authenticator Binaries
-#       uses: goreleaser/goreleaser-action@v1
-#       with:
-#         version: latest
-#         workdir: authenticator
-#         args: release --rm-dist
-#       env:
-#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#     - name: Publish Python SDK
-#       uses: abatilo/actions-poetry@v1.5.0
-#       with:
-#           python_version: 3.7.8
-#           poetry_version: 1.0
-#           working_directory: ./sdk/python/
-#           args: publish --build
-#       env:
-#         POETRY_HTTP_BASIC_PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-#         POETRY_HTTP_BASIC_PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      - name: Release Authenticator Binaries
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          workdir: authenticator
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish Python SDK
+        uses: abatilo/actions-poetry@v1.5.0
+        with:
+            python_version: 3.7.8
+            poetry_version: 1.0
+            working_directory: ./sdk/python/
+            args: publish --build
+        env:
+          POETRY_HTTP_BASIC_PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          POETRY_HTTP_BASIC_PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       - name: Publish Authenticator Docker Image
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
           name: approzium/authenticator
-          username: test
-          password: test
-#         username: ${{ secrets.DOCKER_USERNAME }}
-#         password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
           tags: "latest,${{ env.RELEASE_VERSION }}"
+          buildoptions: "--target authenticator-build"
         env:
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Release Authenticator Binaries
         uses: goreleaser/goreleaser-action@v1
+        working-directory: ./authenticator/
         with:
           version: latest
           args: release --rm-dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,21 +20,33 @@ jobs:
         id: get_version
         run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
 
-      - name: Release Authenticator Binaries
-        uses: goreleaser/goreleaser-action@v1
+#     - name: Release Authenticator Binaries
+#       uses: goreleaser/goreleaser-action@v1
+#       with:
+#         version: latest
+#         workdir: authenticator
+#         args: release --rm-dist
+#       env:
+#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#     - name: Publish Python SDK
+#       uses: abatilo/actions-poetry@v1.5.0
+#       with:
+#           python_version: 3.7.8
+#           poetry_version: 1.0
+#           working_directory: ./sdk/python/
+#           args: publish --build
+#       env:
+#         POETRY_HTTP_BASIC_PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+#         POETRY_HTTP_BASIC_PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+
+      - uses: actions/checkout@master
+      - name: Publish Authenticator Docker Image
+        uses: elgohr/Publish-Docker-Github-Action@master
         with:
-          version: latest
-          workdir: authenticator
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish Python SDK
-        uses: abatilo/actions-poetry@v1.5.0
-        with:
-            python_version: 3.7.8
-            poetry_version: 1.0
-            working_directory: ./sdk/python/
-            args: publish --build
-        env:
-          POETRY_HTTP_BASIC_PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          POETRY_HTTP_BASIC_PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          name: approzium/authenticator
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: "latest,${{ env.RELEASE_VERSION }}"
+          env:
+            COMPOSE_DOCKER_CLI_BUILD: 1
+            DOCKER_BUILDKIT: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,10 @@ jobs:
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
           name: approzium/authenticator
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: test
+          password: test
+#         username: ${{ secrets.DOCKER_USERNAME }}
+#         password: ${{ secrets.DOCKER_PASSWORD }}
           tags: "latest,${{ env.RELEASE_VERSION }}"
         env:
           COMPOSE_DOCKER_CLI_BUILD: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,10 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish PYPI package
+        uses: abatilo/actions-poetry@v1.5.0
+        with:
+            python_version: 3.7.8
+            poetry_version: 1.0
+            working_directory: ./sdk/python/
+            args: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,6 @@ jobs:
 #       env:
 #         POETRY_HTTP_BASIC_PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
 #         POETRY_HTTP_BASIC_PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-
-      - uses: actions/checkout@master
       - name: Publish Authenticator Docker Image
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
@@ -47,6 +45,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           tags: "latest,${{ env.RELEASE_VERSION }}"
-          env:
-            COMPOSE_DOCKER_CLI_BUILD: 1
-            DOCKER_BUILDKIT: 1
+        env:
+          COMPOSE_DOCKER_CLI_BUILD: 1
+          DOCKER_BUILDKIT: 1

--- a/authenticator/.goreleaser.yml
+++ b/authenticator/.goreleaser.yml
@@ -1,6 +1,11 @@
 archives:
     -
         name_template: "{{ .Os }}_{{ .Arch }}"
+        goarch:
+            - 386
+            - amd64
+            - arm
+            - arm64
         goos:
             - linux
             - darwin

--- a/authenticator/.goreleaser.yml
+++ b/authenticator/.goreleaser.yml
@@ -1,6 +1,6 @@
 archives:
     -
-        name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+        name_template: "{ .Os }}_{{ .Arch }}"
         format: zip
         files:
             - none*

--- a/authenticator/.goreleaser.yml
+++ b/authenticator/.goreleaser.yml
@@ -1,6 +1,13 @@
 archives:
     -
         name_template: "{{ .Os }}_{{ .Arch }}"
+        goos:
+            - linux
+            - darwin
+            - windows
+            - freebsd
+            - netbsd
+            - solaris
         format: zip
         files:
             - none*

--- a/authenticator/.goreleaser.yml
+++ b/authenticator/.goreleaser.yml
@@ -1,0 +1,6 @@
+archives:
+    -
+        name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+        format: zip
+        files:
+            - none*

--- a/authenticator/.goreleaser.yml
+++ b/authenticator/.goreleaser.yml
@@ -1,6 +1,6 @@
 archives:
     -
-        name_template: "{ .Os }}_{{ .Arch }}"
+        name_template: "{{ .Os }}_{{ .Arch }}"
         format: zip
         files:
             - none*

--- a/authenticator/.goreleaser.yml
+++ b/authenticator/.goreleaser.yml
@@ -1,6 +1,14 @@
 archives:
     -
+        builds:
+        - authenticator
         name_template: "{{ .Os }}_{{ .Arch }}"
+        format: zip
+        files:
+            - none*
+builds:
+    -
+        id: "authenticator"
         goarch:
             - 386
             - amd64
@@ -13,6 +21,3 @@ archives:
             - freebsd
             - netbsd
             - solaris
-        format: zip
-        files:
-            - none*

--- a/authenticator/.goreleaser.yml
+++ b/authenticator/.goreleaser.yml
@@ -21,3 +21,6 @@ builds:
             - freebsd
             - netbsd
             - solaris
+        ignore:
+            - goos: freebsd
+              goarch: arm64


### PR DESCRIPTION
This adds a workflow that runs on tags that start with "v". Currently, it has just one step that automatically generates the authenticator binaries. See this test release (on a fork) for an [example of what it looks like.](https://github.com/UpGado/approzium/releases/tag/v0.0.0)

Python SDK and authenticator Docker image publishing are added, but I couldn't think of a good approach for testing those beyond the "production"/real world environment.