### PR TITLE
Updates from testing Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,11 @@ vendor/
 .srl
 
 # Binaries
-
 authenticator/bin
 authenticator/pkg
+
+# Terraform-related
+terraform/*/.tfvars
+terraform/*/.tfvars.json
+terraform/*/.terraform
+terraform/*/terraform.tfstate*

--- a/docs/docs/deployment.mdx
+++ b/docs/docs/deployment.mdx
@@ -1,0 +1,9 @@
+---
+title: Deployment
+---
+
+## Terraform 0.12 and Above
+
+To speed you up, we offer stock Terraform configs for deploying the Approzium Authenticator. They live
+[in our Github repo](https://github.com/cyralinc/approzium/tree/develop/terraform). We would also like
+to add support for GCP and Azure, and we welcome community contributions.

--- a/docs/docs/deployment.mdx
+++ b/docs/docs/deployment.mdx
@@ -1,9 +1,0 @@
----
-title: Deployment
----
-
-## Terraform 0.12 and Above
-
-To speed you up, we offer stock Terraform configs for deploying the Approzium Authenticator. They live
-[in our Github repo](https://github.com/cyralinc/approzium/tree/develop/terraform). We would also like
-to add support for GCP and Azure, and we welcome community contributions.

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -2,9 +2,13 @@
 title: Installation
 ---
 
+# Client-Side
+
 ## Client SDKs
 
 - Python: `pip3 install approzium`
+
+# Server-Side
 
 ## Authentication server binaries
 
@@ -53,3 +57,9 @@ Start-Process -Filepath "$PSScriptRoot/authenticator.exe" -ArgumentList $args
 ```
 docker run approzium/authenticator:latest
 ```
+
+## Terraform 0.12 and Above
+
+To speed you up, we offer stock Terraform configs for deploying the Approzium Authenticator. They live
+[in our Github repo](https://github.com/cyralinc/approzium/tree/develop/terraform). We would also like
+to add support for GCP and Azure, and we welcome community contributions.

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -2,19 +2,13 @@
 title: Installation
 ---
 
-# Client-Side
-
 ## Client SDKs
 
 - Python: `pip3 install approzium`
 
-# Server-Side
-
-## Authentication server binaries
+## Server Binaries
 
 - Our binaries are posted with [our releases](https://github.com/cyralinc/approzium/releases).
-
-## Running the server binary
 
 ### Linux
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,1 +1,6 @@
 # Approzium SDK for Python
+
+## Testing
+
+To test whether `pip install` will work for features that have not yet
+been deployed, from this directory run commands like `cd sdk/python & pip3 install .[sqllibs]`.

--- a/terraform/aws/approzium.config.yml
+++ b/terraform/aws/approzium.config.yml
@@ -1,13 +1,15 @@
-# This config file will be used by the deployed Approzium authenticator.
-# Remember to uncomment variables and change them to suit your setup.
-# host: 127.0.0.0
-# httpport: 6000
-# grpcport: 6001
-# loglevel: info
-# logformat: text
-# lograw: false
-# secretsmanager: local
-# or .. if using Vault, use:
-# secretsmanager: vault
-# vaulttoken: ...
-# vaultaddr: ...
+# Please edit it appropriately before production deploys.
+# See https://approzium.com/docs/configuration for more.
+---
+listener:
+  grpc_port: 6001
+  host: "127.0.0.1"
+  http_port: 6000
+logging:
+  log_format: json
+  log_level: info
+  log_raw: false
+secrets:
+  secrets_manager: "local"
+tls:
+  disable_tls: true

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -36,6 +36,7 @@ resource "aws_security_group_rule" "approzium-http-api" {
     from_port = 6000
     to_port = 6000
     protocol = "tcp"
+    cidr_blocks = [var.cidr-block]
 }
 
 resource "aws_security_group_rule" "approzium-grpc" {
@@ -44,6 +45,7 @@ resource "aws_security_group_rule" "approzium-grpc" {
     from_port = 6001
     to_port = 6001
     protocol = "tcp"
+    cidr_blocks = [var.cidr-block]
 }
 
 resource "aws_security_group_rule" "approzium-egress" {
@@ -52,4 +54,5 @@ resource "aws_security_group_rule" "approzium-egress" {
     from_port = 0
     to_port = 0
     protocol = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
 }

--- a/terraform/aws/scripts/install.sh.tpl
+++ b/terraform/aws/scripts/install.sh.tpl
@@ -3,22 +3,20 @@ set -e
 
 sudo apt-get update -y
 sudo apt-get install -y curl unzip
-curl -L "${download-url}" > /tmp/approzium.zip
+curl -o approzium.zip -LO "${download-url}"
 
-cd /tmp
 sudo unzip approzium.zip
 sudo mv authenticator /usr/local/bin/authenticator
-sudo chmod 0755 /usr/local/bin/authenticator
 sudo chown root:root /usr/local/bin/authenticator
 
 # Setup the configuration
-cat <<EOF > /tmp/authenticator-config
+cat <<EOF > approzium.config
 ${config}
 EOF
-sudo mv /tmp/authenticator-config /usr/local/etc/approzium.config.yml
+sudo mv approzium.config /usr/local/etc/approzium.config
 
 # Setup the init script
-cat <<EOF > /tmp/upstart
+cat <<EOF > approzium.conf
 description "Approzium Authenticator server"
 start on runlevel [2345]
 stop on runlevel [!2345]
@@ -31,11 +29,11 @@ script
   fi
 
   exec /usr/local/bin/authenticator \
-    --config="/usr/local/etc/" \
+    --config="/usr/local/etc/approzium.config" \
     >> "${logs-file}" 2>&1
 end script
 EOF
-sudo mv /tmp/upstart /etc/init/approzium.conf
+sudo mv approzium.conf /etc/init/approzium.conf
 
 # Extra install steps (if any)
 ${extra-install}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -3,7 +3,7 @@
 //-------------------------------------------------------------------
 
 variable "download-url" {
-    default = "https://github.com/cyralinc/approzium/releases/download/v0.1.2/linux_amd64.zip"
+    default = "https://github.com/cyralinc/approzium/releases/download/v0.2.0/linux_amd64.zip"
     description = "Download url for Approzium authenticator"
 }
 
@@ -45,6 +45,16 @@ variable "instance_name" {
     description = "Instance name for Approzium"
 }
 
+//-------------------------------------------------------------------
+// An example key name would be "ellen" as it appears in AWS, not "ellen.pem".
+//-------------------------------------------------------------------
 variable "key-name" {
     description = "SSH key name for Approzium instances"
+}
+
+//-------------------------------------------------------------------
+// Example: "192.168. 100.0/24"
+//-------------------------------------------------------------------
+variable "cidr-block" {
+    description = "The CIDR block that should be allowed to ingress into Approzium instances."
 }


### PR DESCRIPTION
This PR has updates I found from testing our Terraform deploy script with Terraform 0.12.29. I ran `terraform plan` and `terraform apply`, and validated that an Approzium instance came up with the Authenticator running as configured.

These changes are intended to be included in the 0.2.0 release.