### PR TITLE
update jpeg-js

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -26,6 +26,7 @@
     "@docusaurus/plugin-ideal-image": "^2.0.0-alpha.39",
     "@docusaurus/preset-classic": "^2.0.0-alpha.58",
     "clsx": "^1.1.1",
+    "jpeg-js": "^0.4.0",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   },

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -5639,6 +5639,11 @@ jpeg-js@^0.3.4:
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.3.7.tgz#471a89d06011640592d314158608690172b1028d"
   integrity sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==
 
+jpeg-js@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.1.tgz#937a3ae911eb6427f151760f8123f04c8bfe6ef7"
+  integrity sha512-jA55yJiB5tCXEddos8JBbvW+IMrqY0y1tjjx9KNVtA+QPmu7ND5j0zkKopClpUTsaETL135uOM2XfcYG4XRjmw==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
resolves the following vulnerability:

# CVE-2020-8175
Vulnerable versions: `< 0.4.0`
Patched version: `0.4.0`
Uncontrolled resource consumption in jpeg-js before 0.4.0 may allow attacker to launch denial of service attacks using specially a crafted JPEG image.