### PR TITLE
Make Go SDK available from home directory

### DIFF
--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -54,6 +54,8 @@ vault write approzium/1.2.3.4:5432 @dbuser1-creds.json
 ```
 
 ## SDK Usage
+
+### Python
 Install the SDK in your client.
 ```shell
 pip3 install 'approzium[sqllibs]'
@@ -74,4 +76,49 @@ conn = connect("host=1.2.3.4 user=dbuser1 dbname=mydbhost", authenticator=auth)
 # use the connection as you typically would. very cool!
 cur = conn.cursor()
 cur.execute('SELECT 1')
+```
+
+### Go
+
+The Approzium Go SDK currently supports MD5 authentication to Postgres.
+
+```
+go get github.com/cyralinc/approzium
+```
+
+```
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/cyralinc/approzium"
+)
+
+func main() {
+	// Create a connection to the Approzium authenticator,
+	// because only the authenticator knows the password.
+	authClient, err := approzium.NewAuthClient("localhost:6001", &approzium.Config{
+		DisableTLS:      true,
+		RoleArnToAssume: os.Getenv("TEST_ASSUMABLE_ARN"), // Optional.
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Now create a Postgres connection without a password.
+	// We also support strings like:
+	// "postgres://pqgotest:@localhost/pqgotest?sslmode=verify-full"
+	dataSourceName := "user=postgres dbname=postgres host=localhost port=5432 sslmode=disable"
+	db, err := authClient.Open("postgres", dataSourceName)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	rows, err := db.Query("SELECT 1")
+    ...
+}
 ```

--- a/sql_driver.go
+++ b/sql_driver.go
@@ -1,0 +1,25 @@
+package approzium
+
+import (
+	sdk "github.com/cyralinc/approzium/sdk/go/approzium"
+)
+
+// This is here to improve the UX for Go developers. It enables them to simply
+// run "go get github.com/cyralinc/approzium" to get the Go SDK, which is normal
+// for them, and for their imports to simply be "github.com/cyralinc/approzium".
+// However, the meat of our SDK does live further down in our project.
+func NewAuthClient(grpcAddress string, config *Config) (*AuthClient, error) {
+	authClient, err := sdk.NewAuthClient(grpcAddress, config.Config)
+	if err != nil {
+		return nil, err
+	}
+	return &AuthClient{authClient}, nil
+}
+
+type AuthClient struct {
+	*sdk.AuthClient
+}
+
+type Config struct {
+	*sdk.Config
+}


### PR DESCRIPTION
This PR adds a pass-through file in the `github.com/cyralinc/approzium` home directory.

This allows the actual SDK to continue living in `github.com/cyralinc/approzium/sdk/go/approzium`, but it enables a more idiomatic experience for Go developers where they'll be able to do the following:

- `go get github.com/cyralinc/approzium`
- `import "github.com/cyralinc/approzium"`