### PR TITLE
Make the health check endpoint return more information

### DIFF
--- a/authenticator/server/api/health.go
+++ b/authenticator/server/api/health.go
@@ -2,6 +2,9 @@ package api
 
 import (
 	"net/http"
+	"time"
+
+	"encoding/json"
 
 	"github.com/cyralinc/approzium/authenticator/server/config"
 	log "github.com/sirupsen/logrus"
@@ -19,10 +22,26 @@ type healthChecker struct {
 	config config.Config
 }
 
+const currentVersion = "0.2.0"
+
+type healthResponse struct {
+	ServerTime string `json:"server_time_utc"`
+	Version    string `json:"version"`
+}
+
 // For most things that use a health check to determine if a service is up,
 // like for AWS and Kubernetes for instance, a service is considered unhealthy
 // if it returns anything other than a 200.
 func (h *healthChecker) ServeHTTP(wr http.ResponseWriter, _ *http.Request) {
 	h.logger.Debug("server is healthy")
-	wr.WriteHeader(200)
+
+	wr.Header().Set("Content-Type", "application/json")
+	response := healthResponse{
+		ServerTime: time.Now().UTC().Format(time.RFC3339),
+		Version:    currentVersion,
+	}
+
+	h.logger.Debugf("healthResponse: %+v", response)
+
+	json.NewEncoder(wr).Encode(response)
 }

--- a/authenticator/server/api/health.go
+++ b/authenticator/server/api/health.go
@@ -35,6 +35,7 @@ type healthResponse struct {
 func (h *healthChecker) ServeHTTP(wr http.ResponseWriter, _ *http.Request) {
 	h.logger.Debug("server is healthy")
 
+	wr.WriteHeader(http.StatusOK)
 	wr.Header().Set("Content-Type", "application/json")
 	response := healthResponse{
 		ServerTime: time.Now().UTC().Format(time.RFC3339),

--- a/authenticator/server/api/health_test.go
+++ b/authenticator/server/api/health_test.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/cyralinc/approzium/authenticator/server/config"
@@ -12,10 +15,25 @@ func TestHealthChecker(t *testing.T) {
 		Host:     "127.0.0.1",
 		GRPCPort: 6001,
 	})
-	testWriter := &testtools.TestResponseWriter{}
-	checker.ServeHTTP(testWriter, nil)
 
-	if testWriter.LastStatusCodeReceived != 200 {
-		t.Fatalf("expected 200 but received %d", testWriter.LastStatusCodeReceived)
+	req, err := http.NewRequest("GET", "/v1/health", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := httptest.NewRecorder()
+
+	checker.ServeHTTP(resp, req)
+
+	if status := resp.Code; status != http.StatusOK {
+		t.Fatalf("expected %v but received %d", http.StatusOK, status)
+	}
+
+	var healthStatus healthResponse
+
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(&healthStatus)
+	if err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Make it so the health check endpoint returns a body like {"server_time_utc": "2020-09-25T16:08:11Z", "version": "0.9.1"}.