### PR TITLE
Increase response verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We use `docker-compose.yml` to quickly and easily provide you with a development
 To spin up an end-to-end development environment based in Docker:
 
 - Ensure you have [Docker](https://www.docker.com/) installed with Buildkit support (Docker 18.09 or higher)
-- In your local environment, run `$ aws configure` and add an access key and secret.
+- In your local environment, run `$ aws configure` and add an access key and a secret.
 - Run `$ make dc-build`. This will build the authenticator and development Docker images.
 - Run `$ docker-compose up`. This will run the authenticator with a Vault backend and will run test database servers (Postgres and MySQL).
 - In another window, `$ make dev`. This will start a shell in the development environment.


### PR DESCRIPTION
This PR is in relation to [this article](https://googleprojectzero.blogspot.com/2020/10/enter-the-vault-auth-issues-hashicorp-vault.html) describing a security vulnerability in Vault. 

We have similar code, so I checked it through and found that we're actually **not** vulnerable to the same issue because we have been checking the `Action` header all along. Just in case, though, I decided to tighten up checking what's in the response we get from AWS to make sure it doesn't have an unexpected content-type header. Also, just in case there's some other header that we don't know about that could be used to slip in JSON, I added a check to make sure the body doesn't look like it could contain JSON.